### PR TITLE
Add vim.ui.input (for renaming variables)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <br/>
 
 ## What's `popui` all about?
-It's a custom UI which overrides neovim's default `vim.ui.select` menu, spawning a floating menu right where your cursor resides.
+It's a custom UI which overrides neovim's default `vim.ui.select` menu and `vim.ui.input` prompt, spawning a floating menu right where your cursor resides.
 <br/><br/>
 <b>See it in action below:</b>
 ![Snapshot #1](https://i.imgur.com/XLYgxeo.png)
@@ -23,6 +23,7 @@ Plugin 'hood/popui.nvim'
 ## Setup
 ```lua
 vim.ui.select = require"popui.ui-overrider"
+vim.ui.input = require"popui.ui-input-overrider"
 ```
 
 ## Customize border style

--- a/lua/popui/input-overrider.lua
+++ b/lua/popui/input-overrider.lua
@@ -28,7 +28,7 @@ local customUIInput = function(opts, onConfirm)
         popupReference = nil
       end
     },
-    mode = 'cursor',
+    mode = 'editor',
     prompt = {
       border = true,
       numbering = true,
@@ -36,9 +36,8 @@ local customUIInput = function(opts, onConfirm)
       border_chars = borders[vim.g.popui_border_style or "rounded"],
       highlight = 'Normal',
       prompt_highlight = 'Normal',
-      init_text = opts.default
+      init_text = opts.default,
     },
-    data = {"textinput"}
   })
 end
 

--- a/lua/popui/ui-input-overrider.lua
+++ b/lua/popui/ui-input-overrider.lua
@@ -30,13 +30,14 @@ local customUIInput = function(opts, onConfirm)
     },
     mode = 'cursor',
     prompt = {
-		border = true,
-		numbering = true,
-		title = opts.prompt,
-        border_chars = borders[vim.g.popui_border_style or "rounded"],
-		highlight = 'Normal',
-		prompt_highlight = 'Normal'
-	},
+      border = true,
+      numbering = true,
+      title = opts.prompt,
+      border_chars = borders[vim.g.popui_border_style or "rounded"],
+      highlight = 'Normal',
+      prompt_highlight = 'Normal',
+      init_text = opts.default
+    },
     data = {"textinput"}
   })
 end

--- a/lua/popui/ui-input-overrider.lua
+++ b/lua/popui/ui-input-overrider.lua
@@ -1,0 +1,44 @@
+local popfix = require"popfix"
+local borders = require"popui/borders"
+
+local popupReference = nil
+
+local customUIInput = function(opts, onConfirm)
+  assert(
+    popupReference == nil,
+    "Busy in other LSP popup."
+  )
+
+  popupReference = popfix:new({
+    close_on_bufleave = true,
+    keymaps = {
+      i = {
+        ['<Cr>'] = function(popup)
+          popup:close(function(_, text) onConfirm(text) end)
+          popupReference = nil
+        end,
+        ['<Esc>'] = function(popup)
+          popup:close()
+          popupReference = nil
+        end
+      },
+    },
+    callbacks = {
+      close = function()
+        popupReference = nil
+      end
+    },
+    mode = 'cursor',
+    prompt = {
+		border = true,
+		numbering = true,
+		title = opts.prompt,
+        border_chars = borders[vim.g.popui_border_style or "rounded"],
+		highlight = 'Normal',
+		prompt_highlight = 'Normal'
+	},
+    data = {"textinput"}
+  })
+end
+
+return customUIInput


### PR DESCRIPTION
I figured I'd just open a PR for this. I don't really know Lua but it seems to be working. There are two issues I'm not sure how to resolve:

1. After renaming a variable or escaping the prompt, it should return to normal mode
2. The prompt should be pre-filled with the current name of the variable. I'm not sure if this is something that popfix supports, however. I think you set this by the `data` field but the documentation for popfix isn't really clear on how that field works.

Anyway, it's a start.