### PR TITLE
fix: set bufhidden to string 'hide' instead of bool true

### DIFF
--- a/lua/popui/core.lua
+++ b/lua/popui/core.lua
@@ -139,7 +139,7 @@ function Core:createBuffer()
 
     vim.bo[bufferNumber].modifiable = true
     vim.bo[bufferNumber].readonly = false
-    vim.bo[bufferNumber].bufhidden = true
+    vim.bo[bufferNumber].bufhidden = "hide"
     vim.bo[bufferNumber].textwidth = 100
 
     return bufferNumber


### PR DESCRIPTION
This PR sets the option 'bufhidden' to "hide" (as that's the option used in other places in the code) instead of the bool true. The help for 'bufhidden' states, that the possible values for bufhidden are the strings ""/<empty>, "hide", "unload", "delete" and "wipe".

Reason:  
I get an error on Neovim v0.7.2 when using `:lua vim.ui.input({prompt = "Select", default = "/tmp/doit"})`:

```
E5108: Error executing lua ...vim/site/pack/packer/start/popui.nvim/lua/popui/core.lua:144: Option 'bufhidden' requires a string value
stack traceback:
        [C]: in function '__newindex'
        ...vim/site/pack/packer/start/popui.nvim/lua/popui/core.lua:144: in function 'createBuffer'
        ...vim/site/pack/packer/start/popui.nvim/lua/popui/core.lua:427: in function 'spawnInputPopup'
        ...ck/packer/start/popui.nvim/lua/popui/input-overrider.lua:4: in function 'input'
        [string ":lua"]:1: in main chunk
```

Note: Interestingly, I don't get that error on v0.8.0. Maybe that's a bug in neovim (as true clears the option)?